### PR TITLE
Fix the phonemic transcription.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Hugo is a blinkmojt (blinking gizmo) located above the door to Schäraton in IDét.
 
-Hugo is prunounced \[/y.go/] (y’gå).
+Hugo is prunounced /y.go/ (y’gå).
 
 ## libhugo
 


### PR DESCRIPTION
Remove the square brackets around the phonemic transcription. Forward slashes are used for phonemic (broad) transcription (which here seems to be for Fr*nch). Alternatively you could transcribe it as /ʏ.gɔː/ or /ʏˈgɔː/ for a Swedish phonemic transcription.

A phonetic transcription (which used only square brackets) would not be appropriate for specifying the pronunciation of a word.